### PR TITLE
Suggesting `bunx` to execute `bunpare`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ You can execute the script automatically when you run `bun install` by adding th
 {
 	// ...
 	"scripts": {
-		"prepare": "npx bunpare"
+		"prepare": "bunx bunpare"
 	}
 	// ...
 }


### PR DESCRIPTION
I suppose that having `bun` installed it would make sense to suggest using `bunx` to execute the `bunpare`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the `prepare` script in the README to recommend using `bunx bunpare` instead of `npx bunpare`, enhancing clarity on script execution methods.
  
- **Chores**
	- Adjusted command execution practices to align with updated recommendations for the Bun environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->